### PR TITLE
should retry ideviceinstaller commands

### DIFF
--- a/bin/briar_ideviceinstaller.rb
+++ b/bin/briar_ideviceinstaller.rb
@@ -4,47 +4,95 @@ require_relative './briar_env'
 
 require 'rainbow'
 require 'ansi/logger'
+require 'retriable'
 
 @log = ANSI::Logger.new(STDOUT)
 
-def ideviceinstaller(device, cmd, opts={})
-  default_opts = {:build_script => ENV['IPA_BUILD_SCRIPT'],
-                  :ipa => ENV['IPA'],
-                  :bundle_id => expect_bundle_id(),
-                  :idevice_installer => expect_ideviceinstaller()}
-  opts = default_opts.merge(opts)
+module Briar
+  module IDEVICEINSTALLER
 
-  cmds = [:install, :uninstall, :reinstall]
-  unless cmds.include? cmd
-    raise "illegal option '#{cmd}' must be one of '#{cmds}'"
-  end
+    include Calabash::Cucumber::Logging
 
-  build_script = opts[:build_script]
-  expect_build_script(build_script) if build_script
+    def ideviceinstaller(device, cmd, opts={})
+      default_opts = {:build_script => ENV['IPA_BUILD_SCRIPT'],
+                      :ipa => ENV['IPA'],
+                      :bundle_id => expect_bundle_id(),
+                      :idevice_installer => expect_ideviceinstaller()}
+      merged = default_opts.merge(opts)
 
-  udid =  read_device_info(device, :udid)
+      cmds = [:install, :uninstall, :reinstall]
+      unless cmds.include? cmd
+        raise "illegal option '#{cmd}' must be one of '#{cmds}'"
+      end
 
-  bin_path = opts[:idevice_installer]
+      build_script = merged[:build_script]
+      expect_build_script(build_script) if build_script
 
-  if cmd == :install
-    if build_script
-      system "#{build_script}"
-      briar_remove_derived_data_dups
+      udid =  read_device_info(device, :udid)
+
+      bin_path = merged[:idevice_installer]
+      bundle_id = merged[:bundle_id]
+
+      case cmd
+        when :install
+          if build_script
+            system "#{build_script}"
+            briar_remove_derived_data_dups
+          end
+
+          ipa = merged[:ipa]
+          expect_ipa(ipa)
+
+          Retriable.retriable do
+            uninstall udid, bundle_id, bin_path
+          end
+
+          Retriable.retriable do
+            install udid, ipa, bundle_id, bin_path
+          end
+        when :uninstall
+          Retriable.retriable do
+            uninstall udid, bundle_id, bin_path
+          end
+        when :reinstall
+          _deprecated('1.1.0', ':reinstall arg has been deprecated; use :install instead', :warn)
+          ideviceinstaller device, :install
+      end
     end
 
-    ipa = opts[:ipa]
-    expect_ipa(ipa)
 
-    cmd = "#{bin_path} -u #{udid} --install #{ipa}"
-    puts "#{Rainbow(cmd).green}"
-    system cmd
-  elsif cmd == :uninstall
-    bundle_id = opts[:bundle_id]
-    cmd = "#{bin_path} -u #{udid} --uninstall #{bundle_id}"
-    puts "#{Rainbow(cmd).green}"
-    system cmd
-  else
-    ideviceinstaller(device, :uninstall)
-    ideviceinstaller(device, :install)
+    def bundle_installed?(udid, bundle_id, installer)
+      cmd = "#{installer} -u #{udid} -l"
+      puts "#{Rainbow(cmd).green}"
+      `#{cmd}`.strip.split(/\s/).include? bundle_id
+    end
+
+    def install(udid, ipa, bundle_id, installer)
+      if bundle_installed? udid, bundle_id, installer
+        puts "#{Rainbow("bundle '#{bundle_id}' is already installed").green}"
+        return true
+      end
+
+      cmd = "#{installer} -u #{udid} --install #{ipa}"
+      system cmd
+      unless bundle_installed?(udid, bundle_id, installer)
+        raise "could not install '#{ipa}' on '#{udid}' with '#{bundle_id}'"
+      end
+      true
+    end
+
+
+    def uninstall(udid, bundle_id, installer)
+      unless bundle_installed? udid, bundle_id, installer
+        return true
+      end
+      cmd = "#{installer} -u #{udid} --uninstall #{bundle_id}"
+      system cmd
+      if bundle_installed?(udid, bundle_id, installer)
+        raise "could not uninstall '#{bundle_id}' on '#{udid}'"
+      end
+      true
+    end
   end
 end
+

--- a/bin/briar_install.rb
+++ b/bin/briar_install.rb
@@ -6,6 +6,8 @@ require 'pry'
 require 'ansi/logger'
 @log = ANSI::Logger.new(STDOUT)
 
+include Briar::IDEVICEINSTALLER
+
 def briar_install_gem
   warn_deprecated('0.1.3', 'will be removed')
   puts 'will install briar gem'
@@ -120,5 +122,5 @@ def briar_install(args)
 end
 
 def briar_device_install(device)
-  ideviceinstaller(device, :reinstall)
+  ideviceinstaller(device, :install)
 end

--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -1,0 +1,11 @@
+## 1.1.0 changelog
+
+
+## features
+
+* [pull 8](https://github.com/jmoody/briar/pull/8) added language keys for Danish and Thai
+    - thanks @crishoj
+    
+## deprecated
+
+- 1.1.0 `:reinstall` is no longer a valid `ideviceinstaller` command - `:install` will always delete the existing .ipa from the device and reinstall.

--- a/changelog/1.1.1.md
+++ b/changelog/1.1.1.md
@@ -1,3 +1,4 @@
+## 1.1.1 changelog
 
 ## release requirements
 
@@ -11,6 +12,3 @@
 *** @optional ***
 
 ## features
-
-* [pull 8](https://github.com/jmoody/briar/pull/8) added language keys for Danish and Thai
-    - thanks @crishoj

--- a/lib/briar/version.rb
+++ b/lib/briar/version.rb
@@ -1,3 +1,3 @@
 module Briar
-  VERSION = '1.0.1'
+  VERSION = '1.1.0-b0'
 end


### PR DESCRIPTION
## motivation

`ideviceinstaller` sometimes fails to install or delete .ipas, so briar should retry failed ideviceinstaller commands.
## notes

Bumped version to 1.1.0-b1 because there is a deprecated public API.

Updated changelogs.
### deprecated
- `:reinstall` is no longer a valid `ideviceinstaller` command - `:install` will always delete the existing .ipa from the device and reinstall.
