### PR TITLE
drop ruby 1.8.7 support

### DIFF
--- a/briar.gemspec
+++ b/briar.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.license = 'MIT'
 
   gem.platform = Gem::Platform::RUBY
-  gem.required_ruby_version = '>= 1.8.7'
+  gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_runtime_dependency 'rbx-require-relative', '~> 0.0'
   gem.add_runtime_dependency 'calabash-cucumber', '~> 0.9.169'

--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -4,6 +4,8 @@ This release improves the `$ briar install < device >` and `$ briar xtc` command
 
 Briar now depends on bundler.  Calls to 3rd party gem binaries will be executed in the context of `bundle exec`.
 
+Briar now requires ruby 1.9.3 or higher.  Ruby 1.8.7 is no longer supported.
+
 ## features
 
 * [pull 8](https://github.com/jmoody/briar/pull/8) added language keys for Danish and Thai
@@ -12,7 +14,10 @@ Briar now depends on bundler.  Calls to 3rd party gem binaries will be executed 
 * [pull 12](https://github.com/jmoody/briar/pull/12) briar now retries ideviceinstaller commands on failures
 
 * [pull 13](https://github.com/jmoody/briar/pull/13) briar xtc command now executes all commands in the context of `bundle exec`
-    
+
+* [pull 14](https://github.com/jmoody/briar/pull/14) briar is dropping support for ruby 1.8.7
+
 ## deprecated
 
 - 1.1.0 `:reinstall` is no longer a valid `ideviceinstaller` command - `:install` will always delete the existing .ipa from the device and reinstall.
+- 1.1.0 drops ruby 1.8.7 support

--- a/lib/briar/version.rb
+++ b/lib/briar/version.rb
@@ -1,3 +1,3 @@
 module Briar
-  VERSION = '1.1.0-b1'
+  VERSION = '1.1.0-b2'
 end


### PR DESCRIPTION
## motivation

Even calabash-ios dropped ruby 1.8.7
