### PR TITLE
Add option to supress 'open' call

### DIFF
--- a/bin/briar_resign.rb
+++ b/bin/briar_resign.rb
@@ -267,7 +267,9 @@ def resign_ipa(options)
   puts "INFO: finished signing '#{ipa}'"
 
 
-  system("open #{work_dir}")
+  unless ENV['BRIAR_DONT_OPEN_ON_RESIGN']
+    system("open #{work_dir}")
+  end
 
 
 end


### PR DESCRIPTION
This is useful when automating, you dont always need a finder window
right away...

Example:

BRIAR_DONT_OPEN_ON_RESIGN=1 briar resign app.ipa ...
- Will not break old behavior
