### PR TITLE
Fixes NoMethodError execption caused by typo

### DIFF
--- a/lib/briar/control/segmented_control.rb
+++ b/lib/briar/control/segmented_control.rb
@@ -32,14 +32,16 @@ module Briar
       def should_see_segment_with_selected_state (control_id, segment_id, selected_state)
         @segment_id = segment_id
         @control_id = control_id
-        res = query("segmentedControl marked:'#{control_id}' child segment marked:'#{segment_id}'",
-                    :isSelected)
+        qstr = "segmentedControl marked:'#{control_id}' child segment marked:'#{segment_id}'"
+        res = query(qstr, :isSelected)
+
         if res.empty?
           screenshot_and_raise "expected to see segmented control '#{control_id}' with segment '#{segment_id}'"
         end
 
-        unless res.first.to_i == selected_state
-          screenshot_and_raise "expected to see segment '#{segment_id}' in '#{control_id}' with selection state '#{selected_state}' but found '#{res.to_i}'"
+        actual_state = res.first
+        unless actual_state == selected_state
+          screenshot_and_raise "expected to see segment '#{segment_id}' in '#{control_id}' with selection state '#{selected_state}' but found '#{actual_state}'"
         end
       end
 


### PR DESCRIPTION
### Expected

```
Waited for 14.0 for segment marked 'grass' to become selected (Calabash::Cucumber::WaitHelpers::WaitError)
```
### Found

```
Then I should see segment "sand" in segmented control "image chooser" is not selected5 ms

undefined method `to_i' for [1]:Array (NoMethodError)
./briar-gem/lib/briar/control/segmented_control.rb:42:in `should_see_segment_with_selected_state'
```
