### PR TITLE
Skip alpha check on button_exists?

### DIFF
--- a/lib/briar/control/button.rb
+++ b/lib/briar/control/button.rb
@@ -4,12 +4,7 @@ module Briar
   module Control
     module Button
       def button_exists? (button_id)
-        res = query("button marked:'#{button_id}'", :alpha)
-        if res.empty?
-          false
-        else
-          res.first.to_i != 0
-        end
+        not query("button marked:'#{button_id}'").empty?
       end
 
       def should_see_button (button_id)


### PR DESCRIPTION
#### Motivation

There is an Apple bug re: arm64 reflection bug on iOS 7.0.* and :alpha is occasionally returning 0 when it should be returning 1.

More to the point, I don't think the check against alpha makes sense.

- [1] http://stackoverflow.com/questions/19874502/nsinvocation-getreturnvalue-with-double-value-produces-0-unexpectedly