### PR TITLE
Upgrade to ansi 1.5

### DIFF
--- a/briar.gemspec
+++ b/briar.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rbx-require-relative', '~> 0.0'
   gem.add_runtime_dependency 'calabash-cucumber', '>= 0.12', '< 1.0'
   gem.add_runtime_dependency 'dotenv', '~> 1.0'
-  gem.add_runtime_dependency 'ansi', '~> 1.4'
+  gem.add_runtime_dependency 'ansi', '~> 1.5'
   gem.add_runtime_dependency 'rainbow', '~> 2.0'
   gem.add_runtime_dependency 'retriable'
   gem.add_runtime_dependency 'bundler'


### PR DESCRIPTION
### Motivation

Ansi 1.5 has a duplicate key fix.

However, it is not a backward compatible change:

https://github.com/rubyworks/ansi/blob/master/HISTORY.md#150--2015-01-16

Fingers crossed?