### PR TITLE
Release/1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.2.0
+
+* Requires xamarin-test-cloud ~> 1.0; use 1.1.9 for older versions
+* Support for XTC teams and organizations
+* Obscure XTC API token and user name when logging
+
 ### 1.1.9
 
 * Fix errant include in lib/irbrc.rb

--- a/bin/briar_help.rb
+++ b/bin/briar_help.rb
@@ -328,6 +328,7 @@ def print_xtc_help
   #{help_env_var('                 IPA', 'path to the .ipa you submitting')}
   #{help_env_var('        XTC_PROFILES', 'cucumber profiles for the XTC')}
   #{help_env_var('         XTC_ACCOUNT', 'name of a directory in ~/.xamarin/test-cloud/<account> that contains the api token')}
+  #{help_env_var('         XTC_USER', 'your XTC email address')}
   #{help_example_comment('if a build script is defined, the .ipa will be built before submission')}
   #{help_env_var('    IPA_BUILD_SCRIPT', '(optional) script that generates the IPA')}
   #{help_example_comment('if you require other gems besides briar')}

--- a/briar.gemspec
+++ b/briar.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rbx-require-relative', '~> 0.0'
   gem.add_runtime_dependency 'calabash-cucumber', '>= 0.12', '< 1.0'
   gem.add_runtime_dependency 'dotenv', '~> 1.0'
-  gem.add_runtime_dependency 'ansi', '~> 1.4'
+  gem.add_runtime_dependency 'ansi', '~> 1.5'
   gem.add_runtime_dependency 'rainbow', '~> 2.0'
   gem.add_runtime_dependency 'retriable'
   gem.add_runtime_dependency 'bundler'

--- a/briar.gemspec
+++ b/briar.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rainbow', '~> 2.0'
   gem.add_runtime_dependency 'retriable'
   gem.add_runtime_dependency 'bundler'
-  gem.add_runtime_dependency 'xamarin-test-cloud'
+  gem.add_runtime_dependency 'xamarin-test-cloud', '~> 1.0'
   gem.add_runtime_dependency 'rake'
 
   gem.add_development_dependency 'travis', '~> 1.7'

--- a/briar.gemspec
+++ b/briar.gemspec
@@ -30,21 +30,14 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_runtime_dependency 'rbx-require-relative', '~> 0.0'
-  gem.add_runtime_dependency 'calabash-cucumber', '>= 0.9.168'
-  gem.add_runtime_dependency 'dotenv', '~> 1.0.2'
+  gem.add_runtime_dependency 'calabash-cucumber', '>= 0.12', '< 1.0'
+  gem.add_runtime_dependency 'dotenv', '~> 1.0'
   gem.add_runtime_dependency 'ansi', '~> 1.4'
   gem.add_runtime_dependency 'rainbow', '~> 2.0'
-  # Downgrade because of xtc gem wants ~> 1.3.3.1.
-  gem.add_runtime_dependency 'retriable', '< 1.5', '>= 1.3'
-  # Test cloud requires 1.3.5.
-  gem.add_runtime_dependency 'bundler', '< 2.0', '>= 1.3.5'
-  gem.add_runtime_dependency 'xamarin-test-cloud', '< 1.0', '>= 0.9.35'
-  gem.add_runtime_dependency 'rake', '~> 10.3'
-
-  # Would like to use 1.2.
-  # https://github.com/xamarin/test-cloud-command-line/issues/3
-  # https://github.com/LessPainful/lesspainfulformatter/pull/1
-  gem.add_runtime_dependency 'syntax', '~> 1.0'
+  gem.add_runtime_dependency 'retriable'
+  gem.add_runtime_dependency 'bundler'
+  gem.add_runtime_dependency 'xamarin-test-cloud'
+  gem.add_runtime_dependency 'rake'
 
   gem.add_development_dependency 'travis', '~> 1.7'
   gem.add_development_dependency 'yard', '~> 0.8'

--- a/lib/briar/version.rb
+++ b/lib/briar/version.rb
@@ -1,3 +1,3 @@
 module Briar
-  VERSION = '1.1.9'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
### 1.2.0

* Requires xamarin-test-cloud ~> 1.0; use 1.1.9 for older versions
* Support for XTC teams and organizations
* Obscure XTC API token and user name when logging