### PR TITLE
Release/1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.2.1
+
+* briar install < device > no longer tries to remove duplicate derived data directories
+
 ### 1.2.0
 
 * Requires xamarin-test-cloud ~> 1.0; use 1.1.9 for older versions

--- a/bin/briar_ideviceinstaller.rb
+++ b/bin/briar_ideviceinstaller.rb
@@ -37,7 +37,6 @@ module Briar
         when :install
           if build_script
             system "#{build_script}"
-            briar_remove_derived_data_dups
           end
 
           ipa = File.expand_path(merged[:ipa])

--- a/lib/briar/version.rb
+++ b/lib/briar/version.rb
@@ -1,3 +1,3 @@
 module Briar
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
### 1.2.1

* briar install < device > no longer tries to remove duplicate derived data directories

This has out lived its usefulness.
