### PR TITLE
Remove dotenv version dependencies; any will do

### DIFF
--- a/briar.gemspec
+++ b/briar.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'rbx-require-relative', '~> 0.0'
   gem.add_runtime_dependency 'calabash-cucumber', '>= 0.12', '< 1.0'
-  gem.add_runtime_dependency 'dotenv', '~> 1.0'
+  gem.add_runtime_dependency 'dotenv'
   gem.add_runtime_dependency 'ansi', '~> 1.5'
   gem.add_runtime_dependency 'rainbow', '~> 2.0'
   gem.add_runtime_dependency 'retriable'


### PR DESCRIPTION
Forcing ~> 1.0 causes conflicts with other gems.

Since we don't need anything fancy, we can rely on any version.