### PR TITLE
Treat iOS 8 as iOS 9 for alerts && sheets

### DIFF
--- a/lib/briar/alerts_and_sheets/action_sheet.rb
+++ b/lib/briar/alerts_and_sheets/action_sheet.rb
@@ -4,7 +4,7 @@ module Briar
 
     def query_str_for_sheet(sheet_id)
       # Ignoring argument because iOS 8 sheets do not retain their accessibilityIdentifier
-      return "view:'_UIAlertControllerView'" if ios8?
+      return "view:'_UIAlertControllerView'" if ios8? or ios9?
       if sheet_id
         "actionSheet marked:'#{sheet_id}'"
       else
@@ -69,7 +69,7 @@ module Briar
 
     def sheet_button_exists? (button_title, sheet_id=nil)
       sheet_query = query_str_for_sheet sheet_id
-      if ios8?
+      if ios8? || ios9?
         query("#{query_str_for_sheet sheet_id} descendant view:'_UIAlertControllerActionView'  marked:'#{button_title}'")
       else
         query("#{sheet_query} child button child label", :text).include?(button_title)
@@ -99,7 +99,7 @@ module Briar
     def touch_sheet_button (button_title, sheet_id=nil)
       sheet_query = query_str_for_sheet sheet_id
       should_see_button_on_sheet button_title, sheet_id
-      if ios8?
+      if ios8? || ios9?
         touch("#{query_str_for_sheet sheet_id} descendant view:'_UIAlertControllerActionView'  marked:'#{button_title}'")
       else
         touch("#{sheet_query} child button child label marked:'#{button_title}'")

--- a/lib/briar/alerts_and_sheets/alert_view.rb
+++ b/lib/briar/alerts_and_sheets/alert_view.rb
@@ -48,7 +48,7 @@ module Briar
                  :retry_frequency => BRIAR_WAIT_RETRY_FREQ,
                  :post_timeout => BRIAR_WAIT_STEP_PAUSE,
                  :timeout_message => msg) do
-          if ios8?
+          if ios8? || ios9?
             not query("view:'_UIAlertControllerView' marked:'#{message}'").empty?
           else
             not uia_query(:view, {:marked => "#{message}"}).empty?
@@ -72,7 +72,7 @@ module Briar
                  :retry_frequency => BRIAR_WAIT_RETRY_FREQ,
                  :post_timeout => BRIAR_WAIT_STEP_PAUSE,
                  :timeout_message => msg) do
-          if ios8?
+          if ios8? || ios9?
             not query("view:'_UIAlertControllerView' marked:'#{message}'").empty?
           else
             not uia_query(:view, {:marked => "#{message}"}).empty?
@@ -117,7 +117,7 @@ module Briar
 
     def touch_alert_button(button_title)
       should_see_alert
-      if ios8?
+      if ios8? || ios9?
         touch("view marked:'#{button_title}' parent view:'_UIAlertControllerCollectionViewCell'")
       elsif ios7?
         touch("view marked:'#{button_title}'")

--- a/lib/briar/email.rb
+++ b/lib/briar/email.rb
@@ -164,7 +164,7 @@ module Briar
 
         # In iOS 8, there is no 'Delete Draft' action sheet, the email compose
         # view animates off.
-        unless ios8?
+        if !(ios8? || ios9?)
           msg = "waited for '#{timeout}' seconds but did not see dismiss email action sheet"
           wait_for(:timeout => timeout,
                    :retry_frequency => BRIAR_WAIT_RETRY_FREQ,


### PR DESCRIPTION
### Motivation

iOS 9 alerts and sheets are like iOS 8's.