### PR TITLE
Release/1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.4.0
+
+* Treat iOS 8 as iOS 9 for alerts && sheets #58
+* Resigning needs to remove existing .xcent #56
+* Support XTC_DSYM for uploading dSYMs #55
+
 ### 1.3.2
 
 * Resigning needs to remove existing .xcent #56

--- a/lib/briar/version.rb
+++ b/lib/briar/version.rb
@@ -1,3 +1,3 @@
 module Briar
-  VERSION = '1.3.2'
+  VERSION = '1.4.0'
 end


### PR DESCRIPTION
### 1.4.0

* Treat iOS 8 as iOS 9 for alerts && sheets #58
* Resigning needs to remove existing .xcent #56
* Support XTC_DSYM for uploading dSYMs #55

Xcode 7/iOS 9